### PR TITLE
Fix OWASP Actions

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -29,7 +29,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
           distribution: 'adopt'
       - name: OWASP dependency checks
-        run: mvn dependency-check:check
+        run: mvn dependency-check:check -DnvdApiKey=${{ secrets.owasp_42_actions }}
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
       - name: Code coverage with Codecov


### PR DESCRIPTION
Fixed OWASP Dependency Check, by adding an API-key to the workflow.