### PR TITLE
Fix ordering, update commit message on release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,15 +38,15 @@ jobs:
       - name: Set version
         if: ${{ github.event.inputs.release-version }} # Only run this step when a release-version is specified.
         run: mvn versions:set -DnewVersion=${{ github.event.inputs.release-version }}
+      - name: Remove Snapshot
+        if: ${{ !github.event.inputs.release-version }}
+        run: mvn versions:set -DremoveSnapshot
       - name: Publish package
         run: mvn --batch-mode deploy -Dmaven.test.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Remove Snapshot
-        if: ${{ !github.event.inputs.release-version }}
-        run: mvn versions:set -DremoveSnapshot
       - name: Retrieve version
         run: |
           echo "version=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_OUTPUT
@@ -64,5 +64,5 @@ jobs:
       - name: Push release commits
         run: |
           git add .
-          git commit -m "Release version"
+          git commit -m "Released version ${{ steps.version.outputs.version }}"
           git push


### PR DESCRIPTION
This pull request updates the Maven release workflow to improve version management and enhance commit messaging. The key changes are focused on restructuring the workflow steps and providing more informative commit messages.

### Workflow improvements:

* [`.github/workflows/maven-release.yml`](diffhunk://#diff-1e1110e4b87ab2617e8052089ef9e5b403618114a3cf009ead9b3925d3bc89aaR41-L49): Moved the "Remove Snapshot" step earlier in the workflow to ensure proper version handling when no release version is provided. This step is now executed before the "Publish package" step.

### Enhanced commit messaging:

* [`.github/workflows/maven-release.yml`](diffhunk://#diff-1e1110e4b87ab2617e8052089ef9e5b403618114a3cf009ead9b3925d3bc89aaL67-R67): Updated the commit message in the "Push release commits" step to include the specific version being released, making the commit history more descriptive.