### PR TITLE
pass OWASP_42_ACTIONS into the workflow from caller

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -9,7 +9,9 @@ on:
       java-version:
         required: true
         type: string
-        default: 8
+    secrets:
+      OWASP_42_ACTIONS:
+        required: true
 jobs:
   build:
 
@@ -29,7 +31,10 @@ jobs:
           java-version: ${{ inputs.java-version }}
           distribution: 'adopt'
       - name: OWASP dependency checks
-        run: mvn dependency-check:check -DnvdApiKey=${{ secrets.OWASP_42_ACTIONS }}
+        env:
+          # Use the secret that was passed in from the caller
+          API_KEY: ${{ secrets.OWASP_42_ACTIONS }}
+        run: mvn dependency-check:check -DnvdApiKey="$API_KEY"
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
       - name: Code coverage with Codecov


### PR DESCRIPTION
-DnvdApiKey=${{ secrets.OWASP_42_ACTIONS }} does not correctly apply the secret. The caller of this script has to pass its own API key.

in our case, that is the same key but github actions doesn't 'bleed' the secrets to the callee. 

the calling scripts will need to look like this: 

`jobs:
  call-build-workflow:
    uses: 42BV/42-github-workflows/.github/workflows/maven-test.yml@main
    with:
      java-version: '21'
    secrets: inherit # This passes the OWASP_42_ACTIONS secret`